### PR TITLE
Fix for SSH key arrays in Vagrant 1.4+

### DIFF
--- a/lib/vagrant-vcloud/action/sync_folders.rb
+++ b/lib/vagrant-vcloud/action/sync_folders.rb
@@ -83,12 +83,16 @@ module VagrantPlugins
             env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
             env[:machine].communicate.sudo(
               "chown #{ssh_info[:username]} '#{guestpath}'")
+              
+            # Since Vagrant 1.4 the private key path may be an array
+            ssh_key_paths = ssh_info[:private_key_path].is_a?(Array) ? ssh_info[:private_key_path] : [ ssh_info[:private_key_path] ]
+            ssh_keys = ssh_key_paths.map {|p| "-i '#{p}'"}.join(" ")
 
             # Rsync over to the guest path using the SSH info
             command = [
               "rsync", "--verbose", "--archive", "-z",
               "--exclude", ".vagrant/", "--exclude", "Vagrantfile",
-              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
+              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_keys}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
 


### PR DESCRIPTION
In Vagrant 1.4 and greater the SSH key can be an array. This was causing a problem even when it was a single key, because the string was getting printed as ["/path/to/key"], including the brackets and quotes, and hence wasn't working.

This fix comes directly from this commit to the openstack plugin:
https://github.com/cloudbau/vagrant-openstack-plugin/commit/48eac2932fa16ccd5fab2e1d2e0d04047f3be7bd
