### PR TITLE
Fix cygdrive path for rsync

### DIFF
--- a/lib/vagrant-vcloud/action/sync_folders.rb
+++ b/lib/vagrant-vcloud/action/sync_folders.rb
@@ -77,7 +77,7 @@ module VagrantPlugins
 
             # on windows rsync.exe requires cygdrive-style paths
             if Vagrant::Util::Platform.windows?
-              hostpath = hostpath.gsub(/^(\w):/) { "/cygdrive/\1" }
+              hostpath = hostpath.gsub(/^(\w):/) { "/cygdrive/#{$1}" }
             end
 
             env[:ui].info(


### PR DESCRIPTION
I finally got a working rsync.exe on a Windows host. I found a typo in the regex to create cygdrive pathes. It always replaced the drive letter with a 0x01 byte. I found the fix in the vagrant-aws plugin sources.
The more difficult part then was find a working combination of ssh.exe + rsync.exe. I tried the preinstalled OpenSSH ssh.exe which created stackdump, installed MinGW rsync.exe, tried the git ssh.exe, finally made it work installing cygwin ssh.exe + cygwin rsync.exe and put them in front of the PATH.

If someone might find it useful, here are my steps using Chocolatey

```
cinst cygwin
cinst cyg-get
set PATH=c:\cygwin\bin;%PATH%
cyg-get openssh
cyg-get rsync
```

Of course, the PATH should be made permanent (but don't use setx which cuts off long paths). Windows is a handicap.

Mitch has added rsync in Vagrant 1.5. What about removing the rsync specific code out of the vagrant-vcloud plugin and using the core vagrant rsync feature? I had a look into the sources of vagrant which does a lot other steps for finding the rsync on a Windows host. 

But this fix helps at least making it useful on windows using cygwin.
