### PR TITLE
Keep waiting on task if it is in 'queued' or 'preRunning' status

### DIFF
--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -1700,7 +1700,7 @@ module VagrantPlugins
             @logger.debug(
               "Evaluating taskid: #{task_id}, current status #{task[:status]}"
             )
-            break if task[:status] != 'running'
+            break if !['queued','preRunning','running'].include?(task[:status])
             sleep 5
           end
 


### PR DESCRIPTION
vCloud director version 5.5.1.1753992

I've been seeing the vApp recompose task fail when vagrant-vcloud moves to provision the second or third VM in my stack.  Traced this to wait_task_completion expecting the task to be in 'running' state but not expecting to see a status of 'preRunning'.  According to the vCloud API docs there is also a possibility of seeing a 'queued' status before the task starts running.

Reference documentation for the status attribute is here: http://pubs.vmware.com/vcd-51/index.jsp?topic=%2Fcom.vmware.vcloud.api.reference.doc_51%2Fdoc%2Ftypes%2FTaskType.html

```
 INFO build_vapp: Waiting for the recompose task to complete ...
"SEND GET https://stgzone02b.bluelock.com/api/task/53d56c61-1ac6-4287-8eda-4bb11291b97c"
"RECV 200"
DEBUG driver_5_1: Evaluating taskid: 53d56c61-1ac6-4287-8eda-4bb11291b97c, current status preRunning
"SEND GET https://stgzone02b.bluelock.com/api/vApp/vapp-8ec989fe-7639-40f0-8d80-cc06f26330e8"
"RECV 200"
```
