### PR TITLE
Fix b3 typo in action_start

### DIFF
--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -56,7 +56,7 @@ module VagrantPlugins
           end
           b.use Call, IsPaused do |env, b2|
             if env[:result]
-              b3.use Resume
+              b2.use Resume
               next
             end
           end


### PR DESCRIPTION
I found a typo in action_start. In the if block there was a b3.use which probably should be a b2.use.
