### PR TITLE
Add winrm_info and rpd_info capability

### DIFF
--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -140,7 +140,21 @@ module VagrantPlugins
       def self.action_read_ssh_info
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConnectVCloud
-          b.use ReadSSHInfo
+          b.use ReadSSHInfo, 22
+        end
+      end
+
+      def self.action_read_winrm_info
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConnectVCloud
+          b.use ReadSSHInfo, 5985
+        end
+      end
+
+      def self.action_read_rdp_info
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConnectVCloud
+          b.use ReadSSHInfo, 3389
         end
       end
 

--- a/lib/vagrant-vcloud/action/read_ssh_info.rb
+++ b/lib/vagrant-vcloud/action/read_ssh_info.rb
@@ -2,8 +2,9 @@ module VagrantPlugins
   module VCloud
     module Action
       class ReadSSHInfo
-        def initialize(app, env)
+        def initialize(app, env, port = 22)
           @app = app
+          @port = port
           @logger = Log4r::Logger.new('vagrant_vcloud::action::read_ssh_info')
         end
 
@@ -68,14 +69,14 @@ module VagrantPlugins
             )
 
             @external_ip = vm_info[:networks]['Vagrant-vApp-Net'][:ip]
-            @external_port = '22'
+            @external_port = "#{@port}"
           else
 
             @logger.debug('Getting port forwarding rules...')
             rules = cnx.get_vapp_port_forwarding_rules(vapp_id)
 
             rules.each do |rule|
-              if rule[:vapp_scoped_local_id] == myhash[:vapp_scoped_local_id] && rule[:nat_internal_port] == '22'
+              if rule[:vapp_scoped_local_id] == myhash[:vapp_scoped_local_id] && rule[:nat_internal_port] == "#{@port}"
                 @external_ip = rule[:nat_external_ip]
                 @external_port = rule[:nat_external_port]
                 break
@@ -109,12 +110,14 @@ module VagrantPlugins
           #
           sleep_counter = 5
 
-          while check_for_ssh(@external_ip, @external_port) == false
-            env[:ui].info(
-              "Waiting for SSH Access on #{@external_ip}:#{@external_port} ... "
-            )
-            sleep sleep_counter
-            sleep_counter += 1
+          if @port == 22
+            while check_for_ssh(@external_ip, @external_port) == false
+              env[:ui].info(
+                "Waiting for SSH Access on #{@external_ip}:#{@external_port} ... "
+              )
+              sleep sleep_counter
+              sleep_counter += 1
+            end
           end
 
           # If we are here, then SSH is ready, continue

--- a/lib/vagrant-vcloud/cap/rdp_info.rb
+++ b/lib/vagrant-vcloud/cap/rdp_info.rb
@@ -1,0 +1,18 @@
+module VagrantPlugins
+  module VCloud
+    module Cap
+      module RDP
+
+        # Reads the RDP forwarded port that currently exists on the machine
+        # itself. This raises an exception if the machine isn't running.
+        # @return [Hash<Integer, Integer>] Host => Guest port mappings.
+        def self.rdp_info(machine)
+          env = machine.action('read_rdp_info')
+          env[:machine_ssh_info]
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/vagrant-vcloud/cap/winrm_info.rb
+++ b/lib/vagrant-vcloud/cap/winrm_info.rb
@@ -1,0 +1,18 @@
+module VagrantPlugins
+  module VCloud
+    module Cap
+      module WinRM
+
+        # Reads the WinRM forwarded port that currently exists on the machine
+        # itself. This raises an exception if the machine isn't running.
+        # @return [Hash<Integer, Integer>] Host => Guest port mappings.
+        def self.winrm_info(machine)
+          env = machine.action('read_winrm_info')
+          env[:machine_ssh_info]
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/vagrant-vcloud/plugin.rb
+++ b/lib/vagrant-vcloud/plugin.rb
@@ -41,6 +41,16 @@ module VagrantPlugins
         Cap::ForwardedPorts
       end
 
+      provider_capability(:vcloud, :winrm_info) do
+        require_relative "cap/winrm_info"
+        Cap::WinRM
+      end
+
+      provider_capability(:vcloud, :rdp_info) do
+        require_relative "cap/rdp_info"
+        Cap::RDP
+      end
+
       # Added a vagrant vcloud-status command to enhance troubleshooting and
       # visibility.
       command('vcloud') do


### PR DESCRIPTION
This code adds the capability for rdp_info and winrm_info, so Vagrant 1.6.3 could read the correct port for a `vagrant rdp` call. Fixes #68 in conjunction with mitchellh/vagrant#3832
