### PR TITLE
Add nested_hypervisor key to enable/disable this feature in VM

### DIFF
--- a/lib/vagrant-vcloud/action/power_on.rb
+++ b/lib/vagrant-vcloud/action/power_on.rb
@@ -15,6 +15,13 @@ module VagrantPlugins
 
           env[:ui].info('Powering on VM...')
 
+          if ! cfg.nested_hypervisor.nil?
+            set_vm_nested_hypervisor = cnx.set_vm_nested_hypervisor(env[:machine].id, cfg.nested_hypervisor)
+            if set_vm_nested_hypervisor
+              cnx.wait_task_completion(set_vm_nested_hypervisor)
+            end
+          end
+
           poweron_vm = cnx.poweron_vm(env[:machine].id)
           cnx.wait_task_completion(poweron_vm)
 

--- a/lib/vagrant-vcloud/config.rb
+++ b/lib/vagrant-vcloud/config.rb
@@ -133,6 +133,9 @@ module VagrantPlugins
       # vApp Id (String)
       attr_accessor :vAppId
 
+      # NestedHypervisor (Bool)
+      attr_accessor :nested_hypervisor
+
       def validate(machine)
         errors = _detected_errors
 

--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -1838,6 +1838,19 @@ module VagrantPlugins
           task_id
         end
 
+        # Enable VM Nested Hardware-Assisted Virtualization
+        def set_vm_nested_hypervisor(vm_id, enable)
+          action = enable ? "enable" : "disable"
+          params = {
+            'method'  => :post,
+            'command' => "/vApp/vm-#{vm_id}/action/#{action}NestedHypervisor"
+          }
+
+          _response, headers = send_request(params)
+          task_id = headers['Location'].gsub("#{@api_url}/task/", '')
+          task_id
+        end
+
         ##
         # Fetch details about a given VM
         def get_vm(vm_id)


### PR DESCRIPTION
When a VM is powered on you can enable/disable the nested hypervisor feature in the VM.
I use this to create VM to build baseboxes with packer within the guest, even 64bit boxes.

Sample configuration in Vagrantfile:

``` ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|

  config.vm.define :"tst" do |tst|
    tst.vm.box = "precise32"
    tst.vm.hostname = "tst"
    tst.vm.provision "shell", path: "scripts/provision.sh"
    tst.vm.provider "vcloud" do |v|
      v.nested_hypervisor = true
    end
  end

end
```
