### PR TITLE
Fix vagrant destroy if only last other VM created

### DIFF
--- a/lib/vagrant-vcloud/action/message_not_created.rb
+++ b/lib/vagrant-vcloud/action/message_not_created.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
 
         def call(env)
           # FIXME: this error should be categorized
-          env[:ui].info(I18n.t('vcloud.vm_not_created'))
+          env[:ui].info(I18n.t('vagrant_vcloud.vm_not_created'))
           @app.call(env)
         end
       end

--- a/lib/vagrant-vcloud/action/unmap_port_forwardings.rb
+++ b/lib/vagrant-vcloud/action/unmap_port_forwardings.rb
@@ -39,30 +39,31 @@ module VagrantPlugins
           @logger.debug('Getting vApp information...')
           vm = cnx.get_vapp(vapp_id)
           myhash = vm[:vms_hash][vm_name.to_sym]
-
           @logger.debug('Getting port forwarding rules...')
           rules = cnx.get_vapp_port_forwarding_rules(vapp_id)
 
-          # FIXME: not familiar with this syntax (tsugliani)
-          new_rule_set = rules.select {
-            |h| !myhash[:vapp_scoped_local_id].include? h[:vapp_scoped_local_id]
-          }
+          unless myhash.nil?
+            # FIXME: not familiar with this syntax (tsugliani)
+            new_rule_set = rules.select {
+              |h| !myhash[:vapp_scoped_local_id].include? h[:vapp_scoped_local_id]
+            }
 
-          @logger.debug("OUR NEW RULE SET, PURGED: #{new_rule_set}")
+            @logger.debug("OUR NEW RULE SET, PURGED: #{new_rule_set}")
 
-          remove_ports = cnx.set_vapp_port_forwarding_rules(
-            vapp_id,
-            'Vagrant-vApp-Net',
-            :fence_mode       => 'natRouted',
-            :parent_network   => cfg.vdc_network_id,
-            :nat_policy_type  => 'allowTraffic',
-            :nat_rules        => new_rule_set
-          )
+            remove_ports = cnx.set_vapp_port_forwarding_rules(
+              vapp_id,
+              'Vagrant-vApp-Net',
+              :fence_mode       => 'natRouted',
+              :parent_network   => cfg.vdc_network_id,
+              :nat_policy_type  => 'allowTraffic',
+              :nat_rules        => new_rule_set
+            )
 
-          wait = cnx.wait_task_completion(remove_ports)
+            wait = cnx.wait_task_completion(remove_ports)
 
-          unless wait[:errormsg].nil?
-            fail Errors::ComposeVAppError, :message => wait[:errormsg]
+            unless wait[:errormsg].nil?
+              fail Errors::ComposeVAppError, :message => wait[:errormsg]
+            end
           end
 
           @app.call(env)


### PR DESCRIPTION
Here is a fix for #78 so that a `vagrant destroy -f` works if only the first VM is created in a multi machine Vagrantfile.

There also was a typo in message_not_created.rb.
