### PR TITLE
Show XML error message, fix for #88

### DIFF
--- a/lib/vagrant-vcloud/driver/base.rb
+++ b/lib/vagrant-vcloud/driver/base.rb
@@ -335,10 +335,10 @@ module VagrantPlugins
                 msg = "Warning: unattended code #{response.status}" +
                 " #{response.reason}"
                 if response.status.to_i == 400
-                  nicexml = Nokogiri.XML(response.body)
-                  elems = nicexml.xpath("//*[@message]")
-                  message = elems[0].attr('message')
-                  msg = msg + ": " + message.to_s
+                  res = Nokogiri.parse(response.body)
+                  error = res.css("Error").first
+                  message = error['message']
+                  msg = msg + ": " + message
                 end
                 if @logger.level == 1
                   ap "[#{Time.now.ctime}] <- RECV #{response.status}"
@@ -347,8 +347,7 @@ module VagrantPlugins
                   ap response.headers
                   ap 'RECV BODY'
                   if response.status.to_i == 400
-                    nicexml = Nokogiri.XML(response.body)
-                    ap nicexml
+                    ap Nokogiri.XML(response.body)
                   else
                     ap respone.body
                   end


### PR DESCRIPTION
Here is a fix for #88.
In case of HTTP 400 response, it will parse the XML response.body and read the message attribute and append that to the message raised.

The error from #88 now looks like this, even without debug logging:

```
C:\jenkins\workspace\windows_2008_r2-100gb_vcloud\boxtest>vagrant up --provider=vcloud
Bringing machine 'default' up with 'vcloud' provider...
==> default: Building vApp...
==> default: vApp windows_2008_r2-100gb-vagrant-vmware-slave-615ef4a5 successfully created.
C:/Users/vagrant/.vagrant.d/gems/gems/vagrant-vcloud-0.4.0/lib/vagrant-vcloud/driver/base.rb:356:in
`send_request': Warning: unattended code 400 Bad Request: Guest customization requires at least version
7299 of VMware tools. You can deselect 'Enable guest customization' for now and select it after installing
VMware tools to perform guest customization. (RuntimeError)
```

Now it is easier to find what caused the problem.

I have also added the intense logging if debug logging is turned on, so also there the response appears with header and body.
