### PR TITLE
Fix WinRM provisioning problem of issue #65

### DIFF
--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
               b2.use ForwardPorts
             end
           end
+          b.use WaitForCommunicator, [:starting, :running]
           b.use Provision
           b.use SyncFolders
         end


### PR DESCRIPTION
Here is my bugfix for issue #65. Adding the `WaitForCommunicator` in the `action_boot` function seems to do it for both unix guests (they still work) and Windows guests running the WinRM communicator of Vagrant 1.6.

The `WaitForCommunicator` exists in Vagrant 1.5.1 (haven't looked in older versions), so this should be backward compatible.
