### PR TITLE
Fix WinRM provisioning problem of issue #65

### DIFF
--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
               b2.use ForwardPorts
             end
           end
+          b.use WaitForCommunicator, [:starting, :running]
           b.use Provision
           b.use SyncFolders
         end


### PR DESCRIPTION
Here is my bugfix for issue #65. Adding the `WaitForCommunicator` in the `action_boot function` seems to do it for both unix guests (they still work) and Windows guests running the WinRM communicator of Vagrant 1.6.

The `WaitForCommunicator` exists in Vagrant 1.5.1 (haven't looked in older versions), so this should be backward compatible.

My Jenkins created five windows boxes last night, only one of them still had a problem with WinRM. Restarting the job worked fine.
But there still is an issue with that situation. The WaitForCommunicator connects to WinRM before the guest customization reboot, then the ssh_info connects to port 22 and then jumps into the rsync code and then the reboot happens.

Is there a way to read the VM guest state that the guest customization hasn't finished yet?

Another idea could be to try a communicator call to read eg. the computer name of the windows guest. If this is not the one in the GuestCustomization XML tags, then we still have to wait...

I have tried to upload the console output into this Gist https://gist.github.com/StefanScherer/d7469c9a1e88e592f140#file-part1-L10076 but the intense logging is too big for gists. In line 10076 the WaitForCommunicator seems to return and the "Waiting for WinRM Access" loop of the plugin begins. So if we find any information from the responses from vCloud to recognize that this windows VM still is not ready for WinRM could help the problem better.

But still it is a better than nothing improvement.
