### PR TITLE
Support global catalog and fix issue #66

### DIFF
--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -218,6 +218,34 @@ module VagrantPlugins
             end
           end
 
+          if result.nil?
+            # catalog not found, search in global catalogs as well
+            # that are not listed in organization directly
+            params = {
+              'method'  => :get,
+              'command' => "/catalogs/query/",
+              'cacheable' => true
+            }
+
+            response, _headers = send_request(params)
+
+            catalogs = {}
+            response.css(
+              "CatalogRecord"
+            ).each do |item|
+              catalogs[item['name']] = item['href'].gsub(
+                "#{@api_url}/catalog/", ''
+              )
+            end
+
+            catalogs.each do |catalog|
+              if catalog[0].downcase == catalog_name.downcase
+                result = catalog[1]
+              end
+            end
+
+          end
+
           result
         end
 


### PR DESCRIPTION
With this PR all global catalogs are accessible by vagrant-vcloud even if they aren't listed in the /api/org/org_id request.

If function `get_catalog_id_by_name` couldn't find the catalog in the org catalog list, then it does an HTTP request `/api/catalogs/query/` and searches for catalogs there.

I haven't tested it with the upload feature. But creating vApps (that's the normal use case for read-only global catalogs) is now possible.
