### PR TITLE
Add optional VM name parameter to make it possible to override 'default'.

### DIFF
--- a/lib/vagrant-vcloud/action/build_vapp.rb
+++ b/lib/vagrant-vcloud/action/build_vapp.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
 
           cfg = env[:machine].provider_config
           cnx = cfg.vcloud_cnx.driver
-          vm_name = env[:machine].name
+          vm_name = cfg.name ? cfg.name.to_sym : env[:machine].name
 
           if cfg.ip_dns.nil?
             dns_address1 = '8.8.8.8'

--- a/lib/vagrant-vcloud/action/forward_ports.rb
+++ b/lib/vagrant-vcloud/action/forward_ports.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
           cfg = @env[:machine].provider_config
           cnx = cfg.vcloud_cnx.driver
           vapp_id = @env[:machine].get_vapp_id
-          vm_name = @env[:machine].name
+          vm_name = cfg.name ? cfg.name.to_sym : @env[:machine].name
 
           # FIXME: why are we overriding this here ?
           #        It's already been taken care during the initial

--- a/lib/vagrant-vcloud/action/handle_nat_port_collisions.rb
+++ b/lib/vagrant-vcloud/action/handle_nat_port_collisions.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
           vapp_id = env[:machine].get_vapp_id
 
           @logger.debug('Getting VM info...')
-          vm_name = env[:machine].name
+          vm_name = cfg.name ? cfg.name.to_sym : env[:machine].name
           vm = cnx.get_vapp(vapp_id)
           vm_info = vm[:vms_hash][vm_name.to_sym]
 

--- a/lib/vagrant-vcloud/action/read_ssh_info.rb
+++ b/lib/vagrant-vcloud/action/read_ssh_info.rb
@@ -42,7 +42,7 @@ module VagrantPlugins
           cfg = env[:machine].provider_config
           cnx = cfg.vcloud_cnx.driver
           vapp_id = env[:machine].get_vapp_id
-          vm_name = env[:machine].name
+          vm_name = cfg.name ? cfg.name.to_sym : env[:machine].name
 
           @logger.debug('Getting vApp information...')
           vm = cnx.get_vapp(vapp_id)

--- a/lib/vagrant-vcloud/action/read_state.rb
+++ b/lib/vagrant-vcloud/action/read_state.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
             cfg = env[:machine].provider_config
             cnx = cfg.vcloud_cnx.driver
             vapp_id = env[:machine].get_vapp_id
-            vm_name = env[:machine].name
+            vm_name = cfg.name ? cfg.name.to_sym : env[:machine].name
 
             if env[:machine].id.nil?
               @logger.info("VM [#{vm_name}] is not created yet")

--- a/lib/vagrant-vcloud/action/unmap_port_forwardings.rb
+++ b/lib/vagrant-vcloud/action/unmap_port_forwardings.rb
@@ -31,7 +31,7 @@ module VagrantPlugins
           cfg = env[:machine].provider_config
           cnx = cfg.vcloud_cnx.driver
           vapp_id = env[:machine].get_vapp_id
-          vm_name = env[:machine].name
+          vm_name = cfg.name ? cfg.name.to_sym : env[:machine].name
 
           cfg.org = cnx.get_organization_by_name(cfg.org_name)
           cfg.vdc_network_id = cfg.org[:networks][cfg.vdc_network_name]

--- a/lib/vagrant-vcloud/config.rb
+++ b/lib/vagrant-vcloud/config.rb
@@ -98,6 +98,10 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :vapp_prefix
 
+      # Name of the VM [optional]
+      #
+      # @return [String]
+      attr_accessor :name
 
       ##
       ## vCloud Director config runtime values


### PR DESCRIPTION
Sometimes is useful to change the VM name created by vagrant within the hypervisor. You may need to specify different VM names based on the provider.

So... just like, for example, on virtualbox provider you can do this:

``` ruby
config.vm.provider 'virtualbox' do |vbox|
    vbox.name = 'rickroll'
end
```

With this PR, you should be able to do this as well:

``` ruby
config.vm.provider 'vcloud' do |vcloud|
    vcloud.name = 'rickroll'
end
```
