### PR TITLE
using catalog_item_name, vAppName and allowing nodes to use differents b...

### DIFF
--- a/lib/vagrant-vcloud/action/build_vapp.rb
+++ b/lib/vagrant-vcloud/action/build_vapp.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
           cfg = env[:machine].provider_config
           cnx = cfg.vcloud_cnx.driver
           vm_name = env[:machine].name
+          box_base_name = env[:machine].box.name
 
           if cfg.ip_dns.nil?
             dns_address1 = '8.8.8.8'
@@ -113,16 +114,15 @@ module VagrantPlugins
 
             vapp_prefix = cfg.vapp_prefix
             vapp_prefix = 'Vagrant' if vapp_prefix.nil?
-
+            vapp_name = cfg.vAppName ? cfg.vAppName : "#{vapp_prefix}-#{Etc.getlogin}-#{Socket.gethostname.downcase}-" + "#{SecureRandom.hex(4)}"
             compose = cnx.compose_vapp_from_vm(
               cfg.vdc_id,
-              "#{vapp_prefix}-#{Etc.getlogin}-#{Socket.gethostname.downcase}-" +
-              "#{SecureRandom.hex(4)}",
+              vapp_name,
               "vApp created by #{Etc.getlogin} running on " +
               "#{Socket.gethostname.downcase} using vagrant-vcloud on " +
               "#{Time.now.strftime("%B %d, %Y")}",
               {
-                vm_name => cfg.catalog_item[:vms_hash].first.last[:id]
+                vm_name => cfg.catalog_item[:vms_hash][box_base_name][:id]
               },
               network_options
             )
@@ -178,7 +178,7 @@ module VagrantPlugins
             recompose = cnx.recompose_vapp_from_vm(
               env[:machine].get_vapp_id,
               {
-                vm_name => cfg.catalog_item[:vms_hash].first.last[:id]
+                vm_name => cfg.catalog_item[:vms_hash][box_base_name][:id]
               },
               network_options
             )

--- a/lib/vagrant-vcloud/action/inventory_check.rb
+++ b/lib/vagrant-vcloud/action/inventory_check.rb
@@ -132,7 +132,7 @@ module VagrantPlugins
           )
           cfg.catalog_item = cnx.get_catalog_item_by_name(
             cfg.catalog_id,
-            box_name
+            cfg.catalog_item_name
           )
 
           @logger.debug("Catalog item is now #{cfg.catalog_item}")


### PR DESCRIPTION
Hi,
thanks for working on this plugin.

When trying to upload boxes I am having the 1% issue.

How ever for our approach we dont need to upload boxes so creating empty boxes with same name than the templates that already are in vcloud makes the trick.

I am passing here the "cfg.catalog_item_name" to the "cnx.get_catalog_item_by_name" function instead of the box, because they don't need to be necessary the same, and one "catalog_item" can have several boxes so in "build_app.rb" I am allowing to retrieve the a given box for a given node.

So from the vagrant file you can make use of different boxes for a given catalog item.

```
config.vm.provider :vcloud do |vcloud|
    vcloud.catalog_name = 'my-catalogue'
    vcloud.catalog_item_name = 'my-exsitent-item-catalogue'
    ....
end

nodes = [
  { :hostname => 'web-vm',
    :box => 'base-image-os-1'
  },
  {
    :hostname => 'db-vm',
    :box => 'base-image-os-2'
  }
]
```

Hope this make sense and help.

Thanks!
