### PR TITLE
enable TLSv1 by updating httpclient

### DIFF
--- a/lib/vagrant-vcloud/version.rb
+++ b/lib/vagrant-vcloud/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
   module VCloud
-    VERSION = '0.4.2'
+    VERSION = '0.4.4'
   end
 end

--- a/vagrant-vcloud.gemspec
+++ b/vagrant-vcloud.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'i18n', '~> 0.6.4'
   s.add_runtime_dependency 'log4r', '~> 1.1.10'
-  s.add_runtime_dependency 'nokogiri', '~> 1.5.5'
-  s.add_runtime_dependency 'httpclient', '~> 2.3.4.1'
+  s.add_runtime_dependency 'nokogiri', '~> 1.6'
+  s.add_runtime_dependency 'httpclient', '~> 2.5.3'
   s.add_runtime_dependency 'ruby-progressbar', '~> 1.1.1'
   s.add_runtime_dependency 'netaddr', '~> 1.5.0'
   # Adding awesome_print because it's just awesome to read XML


### PR DESCRIPTION
After our latest vCloud update + new SSL cert we encounter problems connecting to vCD with vagrant.

```
$ vagrant up --provider=vcloud
/Users/vagrant/.vagrant.d/gems/gems/httpclient-2.3.4.1/lib/httpclient/session.rb:303:in `connect': SSL_connect SYSCALL returned=5 errno=0 state=SSLv3 read server hello A (OpenSSL::SSL::SSLError)
	from /Users/vagrant/.vagrant.d/gems/gems/httpclient-2.3.4.1/lib/httpclient/session.rb:303:in `ssl_connect'
	from /Users/vagrant/.vagrant.d/gems/gems/httpclient-2.3.4.1/lib/httpclient/session.rb:760:in `block in connect'
	from /opt/vagrant/embedded/lib/ruby/2.0.0/timeout.rb:66:in `timeout'
	from /opt/vagrant/embedded/lib/ruby/2.0.0/timeout.rb:97:in `timeout'
```

Trying to connect to the vCD without TLSv1 does not work

```
$ openssl s_client -connect roecloud001:443 -no_tls1
CONNECTED(00000003)
8528:error:140790E5:SSL routines:SSL23_WRITE:ssl handshake failure:s23_lib.c:188:

Nur mit SSLv3 geht es nicht:

$ openssl s_client -connect roecloud001:443 -ssl3
CONNECTED(00000003)
468:error:1409E0E5:SSL routines:SSL3_WRITE_BYTES:ssl handshake failure:s3_pkt.c:530:
```

So I googled if there is a newer version of httpclient lib. An yes, beginning with [httpclient 2.5.0](https://github.com/nahi/httpclient/blob/master/CHANGELOG.md#changes-in-250) the default behaviour has changed again. The version 2.3.4.1 is too old for TLSv1.

I just updated the gemspec file to use the 2.5.3.x version which is already embedded in Vagrant 1.6.5 or 1.7.1.

I had to uninstall the old plugin and install the new one to get rid of the old httpclient gem.

```bash
vagrant plugin uninstall vagrant-vcloud
vagrant plugin install vagrant-vcloud-0.4.4.gem
```

Now I can connect to our vCD again.

BTW: I have seen that some latest changes are only in `master` branch, so this PR diff shows nokogiri 1.5.5 -> 1.6.
