### PR TITLE
Call built-in ProvisionerCleanup on vagrant destroy

### DIFF
--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -120,6 +120,7 @@ module VagrantPlugins
                     b4.use DestroyVM
                   end
                 end
+                b3.use ProvisionerCleanup
               end
             else
               b2.use MessageWillNotDestroy


### PR DESCRIPTION
... otherwise plugins like vagrant-butcher aren't triggered. Compare with: https://github.com/mitchellh/vagrant/blob/v1.7.2/plugins/providers/virtualbox/action.rb#L97

Works fine with vagrant-butcher on multi-machine setup.

(Copy of #111 for develop branch)