### PR TITLE
Nokogiri css doesn't appear to like a space before the selector

### DIFF
--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -688,7 +688,7 @@ module VagrantPlugins
             ).first[:href]).path.gsub('/api/task/', '')
 
           catalog_id = URI(response.css(
-              "AdminCatalog Link [type='application/vnd.vmware.vcloud.catalog+xml']"
+              "AdminCatalog Link[type='application/vnd.vmware.vcloud.catalog+xml']"
             ).first[:href]).path.gsub('/api/catalog/', '')
 
           { :task_id => task_id, :catalog_id => catalog_id }


### PR DESCRIPTION
Nokogiri css selector doesn't appear to like a space between the <Link> element and the [type] selector. It returned an empty array.
