### PR TITLE
Use soft shutdown for halt and reload

### DIFF
--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -46,7 +46,7 @@ module VagrantPlugins
               b2.use MessageNotCreated
               next
             end
-            b2.use action_halt
+            b2.use action_shutdown
             b2.use action_start
             b2.use DisconnectVCloud
           end
@@ -70,7 +70,7 @@ module VagrantPlugins
         end
       end
 
-      def self.action_halt
+      def self.action_poweroff
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
           b.use ConnectVCloud
@@ -78,6 +78,17 @@ module VagrantPlugins
             b2.use Resume if env[:result]
           end
           b.use PowerOff
+        end
+      end
+
+      def self.action_shutdown
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConfigValidate
+          b.use ConnectVCloud
+          b.use Call, IsPaused do |env, b2|
+            b2.use Resume if env[:result]
+          end
+          b.use ShutDown
         end
       end
 
@@ -116,7 +127,7 @@ module VagrantPlugins
 
                 b3.use Call, IsRunning do |env3, b4|
                 # If the VM is running, must power off
-                  b4.use action_halt if env3[:result]
+                  b4.use action_poweroff if env3[:result]
                 end
                 b3.use Call, IsLastVM do |env3, b4|
                   if env3[:result]
@@ -297,6 +308,8 @@ module VagrantPlugins
                action_root.join('read_state')
       autoload :Resume,
                action_root.join('resume')
+      autoload :ShutDown,
+               action_root.join('shut_down')
       autoload :Suspend,
                action_root.join('suspend')
       autoload :SyncFolders,

--- a/lib/vagrant-vcloud/action.rb
+++ b/lib/vagrant-vcloud/action.rb
@@ -46,7 +46,7 @@ module VagrantPlugins
               b2.use MessageNotCreated
               next
             end
-            b2.use action_shutdown
+            b2.use action_halt
             b2.use action_start
             b2.use DisconnectVCloud
           end
@@ -81,7 +81,7 @@ module VagrantPlugins
         end
       end
 
-      def self.action_shutdown
+      def self.action_halt
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
           b.use ConnectVCloud

--- a/lib/vagrant-vcloud/action/shut_down.rb
+++ b/lib/vagrant-vcloud/action/shut_down.rb
@@ -1,0 +1,33 @@
+module VagrantPlugins
+  module VCloud
+    module Action
+      class ShutDown
+        def initialize(app, env)
+          @app = app
+          @logger = Log4r::Logger.new('vagrant_vcloud::action::shutdown')
+        end
+
+        def call(env)
+          cfg = env[:machine].provider_config
+          cnx = cfg.vcloud_cnx.driver
+
+          vapp_id = env[:machine].get_vapp_id
+          vm_id = env[:machine].id
+
+          test_vapp = cnx.get_vapp(vapp_id)
+
+          @logger.debug(
+            "Number of VMs in the vApp: #{test_vapp[:vms_hash].count}"
+          )
+
+          # Shutdown VM
+          env[:ui].info('Shutting down VM...')
+          task_id = cnx.shutdown_vm(vm_id)
+          cnx.wait_task_completion(task_id)
+
+          @app.call env
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -571,7 +571,7 @@ module VagrantPlugins
         end
 
         ##
-        # Shutdown a given VM
+        # Poweroff a given VM
         # Using undeploy as a REAL powerOff
         # Only poweroff will put the VM into a partially powered off state.
         def poweroff_vm(vm_id)
@@ -592,6 +592,31 @@ module VagrantPlugins
             'application/vnd.vmware.vcloud.undeployVAppParams+xml'
           )
           task_id = URI(headers['Location']).path.gsub('/api/task/', '')
+          task_id
+        end
+
+        ##
+        # Shutdown a given VM
+        # Using undeploy with shutdown, without VMware Tools this WILL FAIL.
+        #
+        def shutdown_vm(vm_id)
+          builder = Nokogiri::XML::Builder.new do |xml|
+            xml.UndeployVAppParams(
+            'xmlns' => 'http://www.vmware.com/vcloud/v1.5'
+          ) { xml.UndeployPowerAction 'shutdown' }
+          end
+
+          params = {
+            'method'  => :post,
+            'command' => "/vApp/vm-#{vm_id}/action/undeploy"
+          }
+
+          _response, headers = send_request(
+            params,
+            builder.to_xml,
+            'application/vnd.vmware.vcloud.undeployVAppParams+xml'
+          )
+          task_id = headers['Location'].gsub("#{@api_url}/task/", '')
           task_id
         end
 

--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -616,7 +616,7 @@ module VagrantPlugins
             builder.to_xml,
             'application/vnd.vmware.vcloud.undeployVAppParams+xml'
           )
-          task_id = headers['Location'].gsub("#{@api_url}/task/", '')
+          task_id = URI(headers['Location']).path.gsub('/api/task/', '')
           task_id
         end
 


### PR DESCRIPTION
I got a lot of trouble using Windows VM's in vCloud when I need eg. the vagrant-reload provisioner.
The current implementation just powers off the VM without a soft shutdown of the Windows OS.

This PR is tested with Vagrant 1.7.4 and the `vagrant reload`, `vagrant halt` and `vagrant-reload` provision step.

Only disadvantage is that this only works with VMware tools installed in the guest VM.

A `vagrant destroy` still just powers off the VM.
