### PR TITLE
Fix for Vagrant 1.9.1, make plugin installable on several Vagrant versions

### DIFF
--- a/lib/vagrant-vcloud/driver/version_5_1.rb
+++ b/lib/vagrant-vcloud/driver/version_5_1.rb
@@ -1002,8 +1002,7 @@ module VagrantPlugins
           )
 
           vapp_id = URI(headers['Location']).path.gsub('/api/vApp/vapp-', '')
-
-          task = response.css("Task [operationName='vdcRecomposeVapp']").first
+          task = response.css("Task[operationName='vdcRecomposeVapp']").first
           task_id = URI(task['href']).path.gsub('/api/task/', '')
 
           { :vapp_id => vapp_id, :task_id => task_id }

--- a/vagrant-vcloud.gemspec
+++ b/vagrant-vcloud.gemspec
@@ -12,20 +12,16 @@ Gem::Specification.new do |s|
   s.summary = 'VMware vCloud Director® provider'
   s.description = 'Enables Vagrant to manage machines with VMware vCloud Director®.'
 
-  s.add_runtime_dependency 'i18n', '~> 0.6.4'
-  s.add_runtime_dependency 'log4r', '~> 1.1.10'
-  s.add_runtime_dependency 'nokogiri', '~> 1.6'
-  s.add_runtime_dependency 'httpclient', '~> 2.3.4.1'
-  s.add_runtime_dependency 'ruby-progressbar', '~> 1.1.1'
-  s.add_runtime_dependency 'netaddr', '~> 1.5.0'
+  s.add_runtime_dependency 'ruby-progressbar', '~> 1.1'
+  s.add_runtime_dependency 'netaddr', '~> 1.5'
   # Adding awesome_print because it's just awesome to read XML
-  s.add_runtime_dependency 'awesome_print', '~> 1.2.0'
-  s.add_runtime_dependency 'terminal-table', '~> 1.4.5'
+  s.add_runtime_dependency 'awesome_print', '~> 1.2'
+  s.add_runtime_dependency 'terminal-table', '~> 1.4'
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec-core', '~> 2.12.2'
-  s.add_development_dependency 'rspec-expectations', '~> 2.12.1'
-  s.add_development_dependency 'rspec-mocks', '~> 2.12.1'
+  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rspec-core', '~> 2.12'
+  s.add_development_dependency 'rspec-expectations', '~> 2.12'
+  s.add_development_dependency 'rspec-mocks', '~> 2.12'
 
   s.files = `git ls-files`.split($/)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
I had problems running vagrant-vcloud with Vagrant 1.8.x and above spinning up a second VM in a [multi VM Vagrantfile](https://github.com/StefanScherer/vcloud-scenarios/tree/master/vappnetwork). It crashed.

By removing the space in `Task [operationName='vdcRecomposeVapp']` the driver now works.

I also tried to use the plugin with Vagrant 1.7.4, 1.8.7 and 1.9.1 in a Docker container and removed some hard dependencies from the gemspec file.

It now can be installed without problems in Vagrant 1.7.4., 1.8.7 and 1.9.1, as all these versions have nokogiri and httpclient installed, but in their pinned versions. The vagrant-vcloud plugin seems to work fine with all these preinstalled gems.
