### PR TITLE
Add helper to test plugin with several Vagrant versions

### DIFF
--- a/integration/.gitignore
+++ b/integration/.gitignore
@@ -1,0 +1,2 @@
+.vagrant/
+!Vagrantfile

--- a/integration/Dockerfile
+++ b/integration/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu
+
+ARG VAGRANT_VERSION=1.9.1
+
+ENV	\
+  BOX_WINDOWS=https://github.com/plossys/vagrant-vcloud/raw/my/helper/dummy-windows.box \
+  BOX_LINUX=https://github.com/plossys/vagrant-vcloud/raw/my/helper/dummy-linux.box
+
+RUN apt-get update -y && \
+    apt-get install -y build-essential liblzma-dev zlib1g-dev git openssh-client rsync curl && \
+    ln -sf bash /bin/sh && \
+    curl -L https://releases.hashicorp.com/vagrant/${VAGRANT_VERSION}/vagrant_${VAGRANT_VERSION}_x86_64.deb > /tmp/vagrant_x86_64.deb && \
+    dpkg -i /tmp/vagrant_x86_64.deb && \
+    rm -f /tmp/vagrant_x86_64.deb && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    vagrant plugin list && \
+    ln -s /user/Vagrantfile /root/.vagrant.d/Vagrantfile && \
+    vagrant box add windows_2016 ${BOX_WINDOWS} && \
+    vagrant box add ubuntu1404 ${BOX_LINUX}
+
+WORKDIR /plugin
+COPY . /plugin
+
+RUN /opt/vagrant/embedded/bin/gem build vagrant-vcloud.gemspec && \
+    vagrant --version && \
+    vagrant plugin install ./vagrant-vcloud*.gem && \
+    vagrant plugin list
+
+WORKDIR /work
+
+VOLUME ["/work", "/user"]
+
+ENTRYPOINT ["vagrant"]

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,0 +1,34 @@
+# integration
+
+Easily run some integration tests with several versions of Vagrant in a Docker container.
+
+## Build vagrant base images
+
+To build the vagrant base images just run
+
+```
+./build-images.sh
+```
+
+This also tests if the plugin is installable in the latest three minor versions of Vagrant.
+
+Afterwards you have some Docker images with specific Vagrant versions:
+
+```
+$ docker images | grep vagrant
+vagrant                     1.7.4               4bd54f063310        About an hour ago   598.9 MB
+vagrant                     1.8.7               9d70aa570e14        About an hour ago   594.1 MB
+vagrant                     1.9.1               446c0fad9f55        About an hour ago   609.8 MB
+```
+
+## Run a test
+
+In this folder there is a `Vagrantfile` with two VM's in a vApp. Spinning up that vApp you will test if rsync works and if adding a VM to a vApp works.
+
+You can use all commands of Vagrant with that wrapper script `test.sh`. As first argument you have to specify the Docker image name, eg. `vagrant:1.9.1`
+
+```
+./test.sh vagrant:1.7.4 up
+```
+
+If you change some code you have to rebuild the base images at the moment.

--- a/integration/Vagrantfile
+++ b/integration/Vagrantfile
@@ -1,0 +1,33 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$script=<<EOF
+echo "Hello from `hostname`"
+echo "Listing of /vagrant"
+ls -l /vagrant
+EOF
+
+Vagrant.configure("2") do |config|
+  if Vagrant.has_plugin?("vagrant-vcloud")
+    config.vm.provider :vcloud do |vcloud|
+      vcloud.vapp_prefix = "integrationtest"
+      vcloud.ip_subnet = "172.16.32.0/255.255.255.0"
+    end
+    config.vm.provider :vcloud do |cloud, override|
+      override.vm.usable_port_range = 2200..2999
+    end
+  end
+
+  config.vm.define :"tst" do |cfg|
+    cfg.vm.box = "ubuntu1404"
+    cfg.vm.hostname = "tst"
+    cfg.vm.provision "shell", inline: $script
+  end
+
+  config.vm.define :"tst2" do |cfg|
+    cfg.vm.box = "ubuntu1404"
+    cfg.vm.hostname = "tst2"
+    cfg.vm.provision "shell", inline: $script
+  end
+
+end

--- a/integration/build-images.sh
+++ b/integration/build-images.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+MY_PATH="`dirname \"$0\"`"              # relative
+MY_PATH="`( cd \"$MY_PATH\" && pwd  )`"  # absolutized and normalized
+cd $MY_PATH/..
+docker build -t vagrant:1.9.1 --build-arg VAGRANT_VERSION=1.9.1 -f integration/Dockerfile .
+docker build -t vagrant:1.8.7 --build-arg VAGRANT_VERSION=1.8.7 -f integration/Dockerfile .
+docker build -t vagrant:1.7.4 --build-arg VAGRANT_VERSION=1.7.4 -f integration/Dockerfile .

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ $1 == '--help' || $1 == '' ]]; then
+  echo "A helper to test plugin sources with several Vagrant versions."
+  echo "Usage: $0 <image> <command>"
+  echo "Examples:"
+  echo "$0 vagrant:1.7.4 up"
+  echo "$0 vagrant:1.8.7 up"
+  echo "$0 vagrant:1.9.1 up"
+  echo "$0 vagrant:1.9.1 destroy -f"
+  exit 0
+fi
+
+image=$1
+shift
+
+docker run --rm -it \
+  -v "$(pwd):/work" \
+  -v ~/.vagrant.d/Vagrantfile:/user/Vagrantfile \
+  "$image" "$@"


### PR DESCRIPTION
This is my quick test setup to test the plugin sources with several versions of Vagrant in Docker containers. A very similar setup was used to test #137 

```bash
cd integration
./build-images.sh
./test.sh vagrant:1.9.1 up
./test.sh vagrant:1.8.7 status
./test.sh vagrant:1.7.4 destroy -f
```
