### PR TITLE
Add support for vCloud Director 8.0, API 9.0

### DIFF
--- a/lib/vagrant-vcloud/driver/meta.rb
+++ b/lib/vagrant-vcloud/driver/meta.rb
@@ -50,7 +50,8 @@ module VagrantPlugins
             '5.1' => Version_5_1,
             '5.5' => Version_5_1, # Binding vCloud 5.5 API on our current 5.1 implementation
             '5.6' => Version_5_1, # Binding vCHS API on our current 5.1 implementation
-            '5.7' => Version_5_1  # Binding vCHS API on our current 5.1 implementation
+            '5.7' => Version_5_1, # Binding vCHS API on our current 5.1 implementation
+            '9.0' => Version_5_1  # Binding vCHS API on our current 5.1 implementation
           }
 
           if @version.start_with?('0.9') ||


### PR DESCRIPTION
Yes, I know we're late to the party. But yesterday we had an update to vCloud Director 8.0 and today the vagrant-vcloud plugin no longer works due to API version constraints.
Update to 8.10 is planned very soon.

Should we switch to vagrant-vcloudair plugin, I've seen that there at least API 11.0 was added.
