### PR TITLE
Update gem dependencies to get install with Vagrant v1.9.3 to work

### DIFF
--- a/vagrant-vcloud.gemspec
+++ b/vagrant-vcloud.gemspec
@@ -12,20 +12,20 @@ Gem::Specification.new do |s|
   s.summary = 'VMware vCloud Director® provider'
   s.description = 'Enables Vagrant to manage machines with VMware vCloud Director®.'
 
-  s.add_runtime_dependency 'i18n', '~> 0.6.4'
+  s.add_runtime_dependency 'i18n', '~> 0.8.0'
   s.add_runtime_dependency 'log4r', '~> 1.1.10'
-  s.add_runtime_dependency 'nokogiri', '~> 1.6'
-  s.add_runtime_dependency 'httpclient', '~> 2.3.4.1'
-  s.add_runtime_dependency 'ruby-progressbar', '~> 1.1.1'
-  s.add_runtime_dependency 'netaddr', '~> 1.5.0'
+  s.add_runtime_dependency 'nokogiri', '~> 1.6.7.1'
+  s.add_runtime_dependency 'httpclient', '~> 2.8.3'
+  s.add_runtime_dependency 'ruby-progressbar', '~> 1.8.1'
+  s.add_runtime_dependency 'netaddr', '~> 1.5.1'
   # Adding awesome_print because it's just awesome to read XML
-  s.add_runtime_dependency 'awesome_print', '~> 1.2.0'
-  s.add_runtime_dependency 'terminal-table', '~> 1.4.5'
+  s.add_runtime_dependency 'awesome_print', '~> 1.7.0'
+  s.add_runtime_dependency 'terminal-table', '~> 1.7.3'
 
   s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec-core', '~> 2.12.2'
-  s.add_development_dependency 'rspec-expectations', '~> 2.12.1'
-  s.add_development_dependency 'rspec-mocks', '~> 2.12.1'
+  s.add_development_dependency 'rspec-core', '~> 3.5.4'
+  s.add_development_dependency 'rspec-expectations', '~> 3.5.0'
+  s.add_development_dependency 'rspec-mocks', '~> 3.5.0'
 
   s.files = `git ls-files`.split($/)
   s.executables = s.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Resolves #140

**NOTE:** I'm still working on testing if the plugin actually works with Vagrant v1.9.3.  This is just to solve the first hurdle of installation.