### PR TITLE
Support any vCloud API version using default driver

### DIFF
--- a/lib/vagrant-vcloud/driver/meta.rb
+++ b/lib/vagrant-vcloud/driver/meta.rb
@@ -46,13 +46,6 @@ module VagrantPlugins
 
           # Instantiate the proper version driver for vCloud
           @logger.debug("Finding driver for vCloud version: #{@version}")
-          driver_map   = {
-            '5.1' => Version_5_1,
-            '5.5' => Version_5_1, # Binding vCloud 5.5 API on our current 5.1 implementation
-            '5.6' => Version_5_1, # Binding vCHS API on our current 5.1 implementation
-            '5.7' => Version_5_1, # Binding vCHS API on our current 5.1 implementation
-            '9.0' => Version_5_1  # Binding vCHS API on our current 5.1 implementation
-          }
 
           if @version.start_with?('0.9') ||
              @version.start_with?('1.0') ||
@@ -61,19 +54,7 @@ module VagrantPlugins
             raise Errors::VCloudOldVersion, :version => @version
           end
 
-          driver_klass = nil
-          driver_map.each do |key, klass|
-            if @version.start_with?(key)
-              driver_klass = klass
-              break
-            end
-          end
-
-          if !driver_klass
-            supported_versions = driver_map.keys.sort.join(', ')
-            raise Errors::VCloudInvalidVersion,
-                  :supported_versions => supported_versions
-          end
+          driver_klass = Version_5_1 # Binding any vCloud API on our current 5.1 implementation
 
           @logger.info("Using vCloud driver: #{driver_klass}")
           @driver = driver_klass.new(@hostname, @username, @password, @org_name)


### PR DESCRIPTION
Hi @frapposelli 
I totally missed that in the meantime we updated to vCloud Director 8.x with API version 20.1.
As I read in the latest release notes the vCloud Director 8.20 may have API version 27.0.
So instead of updating the checks every time I just removed the API version check with this PR and still use the one and only implementation of the 5.1 ruby file.

I think that would help more people until we find a client incompability and have the need for a second client API implementation.

Would be great if you find some more minutes for another release :-)
