### PR TITLE
Use TLSv1_2 to support vCD 9.1

### DIFF
--- a/lib/vagrant-vcloud/driver/base.rb
+++ b/lib/vagrant-vcloud/driver/base.rb
@@ -288,8 +288,8 @@ module VagrantPlugins
             # Create a new HTTP client
             clnt = HTTPClient.new
 
-            # Set SSL proto to TLSv1
-            clnt.ssl_config.ssl_version = :TLSv1
+            # Set SSL proto to TLSv1_2
+            clnt.ssl_config.ssl_version = :TLSv1_2
 
             # Disable SSL cert verification
             clnt.ssl_config.verify_mode = (OpenSSL::SSL::VERIFY_NONE)
@@ -404,8 +404,8 @@ module VagrantPlugins
             # Create a new HTTP client
             clnt = HTTPClient.new
 
-            # Set SSL proto to TLSv1
-            clnt.ssl_config.ssl_version = :TLSv1
+            # Set SSL proto to TLSv1_2
+            clnt.ssl_config.ssl_version = :TLSv1_2
 
             # Disable SSL cert verification
             clnt.ssl_config.verify_mode = (OpenSSL::SSL::VERIFY_NONE)

--- a/lib/vagrant-vcloud/driver/meta.rb
+++ b/lib/vagrant-vcloud/driver/meta.rb
@@ -105,8 +105,8 @@ module VagrantPlugins
           # Create a new HTTP client
           clnt = HTTPClient.new
 
-          # Set SSL proto to TLSv1
-          clnt.ssl_config.ssl_version = :TLSv1
+          # Set SSL proto to TLSv1_2
+          clnt.ssl_config.ssl_version = :TLSv1_2
 
           # Disable SSL cert verification
           clnt.ssl_config.verify_mode = (OpenSSL::SSL::VERIFY_NONE)


### PR DESCRIPTION
We have updated our vCloud Director to 9.1 and had the problem to communicate with the Vagrant plugin.
After updating to TLS v1.2 the communication works again.
We'll investigate further if this was the only problem.

